### PR TITLE
fix: adds runtime dependencies to authzed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'grpc', '~> 1.41'
-gem 'grpc-tools'
-gem 'rspec', '~> 3.0'
+gemspec
+
+group :development, :test do
+  gem "rake"
+end

--- a/authzed.gemspec
+++ b/authzed.gemspec
@@ -1,17 +1,22 @@
 Gem::Specification.new do |s|
-  s.name        = 'authzed'
-  s.version     = '0.3.0'
-  s.licenses    = ['Apache-2.0']
+  s.name        = "authzed"
+  s.version     = "0.3.1"
+  s.licenses    = ["Apache-2.0"]
   s.summary     = "Ruby bindings for Authzed API"
   s.description = "Authzed is the best way to build robust and scalable permissions systems. See https://authzed.com for more details."
   s.authors     = ["Authzed"]
-  s.email       = 'support@authzed.com'
+  s.email       = "support@authzed.com"
   s.files       = Dir.glob(%w[LICENSE README.md {exe,lib}/**/*]).reject { |f| File.directory?(f) }
-  s.homepage    = 'https://authzed.com'
+  s.homepage    = "https://authzed.com"
   s.metadata    = { 
     "bug_tracker_uri" => "https://github.com/authzed/authzed-rb/issues",
     "github_repo"     => "ssh://github.com/authzed/authzed-rb",
     "homepage_uri"    => "https://authzed.com",
     "source_code_uri" => "https://github.com/authzed/authzed-rb",
   }
+
+  s.add_runtime_dependency "grpc", "~> 1.41"
+  s.add_runtime_dependency "grpc-tools", "~> 1.41"
+
+  s.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
+ Adds missing dependencies. Without runtime dependencies, authzed will not run properly:

```
 require 'authzed'
LoadError: cannot load such file -- google/protobuf
from /Users/somedev/.rbenv/versions/2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
Caused by LoadError: cannot load such file -- authzed
from /Users/somedev/.rbenv/versions/2.7.1/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
```