### PR TITLE
introduces dependency update automation with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'bundler'
+    directory: '/'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
Enables dependency updates using Dependabot

I'd suggest merging https://github.com/authzed/authzed-rb/pull/24 first, otherwise Dependabot will open the corresponding updates already handled in that PR