### PR TITLE
add CODEOWNERS and update CLA Assistant

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,6 +1,6 @@
 ---
-name: "CLA Assistant"
-on:
+name: "CLA"
+on:  # yamllint disable-line rule:truthy
   issue_comment:
     types:
       - "created"
@@ -9,21 +9,12 @@ on:
       - "opened"
       - "closed"
       - "synchronize"
-
 jobs:
-  CLAssistant:
+  cla:
+    name: "Check Signature"
     runs-on: "ubuntu-latest"
     steps:
-      - name: "CLA Assistant"
-        if: "(github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'"
-        uses: "cla-assistant/github-action@v2.1.3-beta"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          PERSONAL_ACCESS_TOKEN: "${{ secrets.CLA_ASSISTANT_ACCESS_TOKEN }}"
+      - uses: "authzed/actions/cla-check@main"
         with:
-          remote-organization-name: "authzed"
-          remote-repository-name: "cla"
-          path-to-signatures: "v1/signatures.json"
-          path-to-document: "https://github.com/authzed/cla/blob/main/v1/icla.md"
-          branch: "main"
-          allowlist: "authzedbot,dependabot-bot"
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          cla_assistant_token: "${{ secrets.CLA_ASSISTANT_ACCESS_TOKEN }}"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @authzed/spicedb-maintainers


### PR DESCRIPTION
Add CODEOWNERS file so the so the spicedb team gets automatically pinged for reviews on PRs

Also updates CLA assistant CI job to use the same centralized GitHub Action as `authzed/spicedb` so it gets to ignore dependabot for CLA.