### PR TITLE
correct gem version for v0.7.1 release

### DIFF
--- a/authzed.gemspec
+++ b/authzed.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "authzed"
-  s.version     = "0.7.0"
+  s.version     = "0.7.1"
   s.licenses    = ["Apache-2.0"]
   s.summary     = "Ruby bindings for Authzed API"
   s.description = "Authzed is the best way to build robust and scalable permissions systems. See https://authzed.com for more details."


### PR DESCRIPTION
This caused the release to fail as it tried to push a gem that already existed