### PR TITLE
Update Gemfile.lock with updated gem version number during release workflow

### DIFF
--- a/.github/workflows/automatic-api-update.yaml
+++ b/.github/workflows/automatic-api-update.yaml
@@ -22,6 +22,11 @@ jobs:
           UPDATED_STATUS: ${{ steps.buf-update.outputs.updated }}
         run: |
           echo "Update status: $UPDATED_STATUS"
+      - name: "Install ruby and dependencies"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "3.3.0"
+          bundler-cache: true
       - name: "Update package version"
         uses: authzed/actions/semver-update@main
         if: steps.buf-update.outputs.updated == 'true'
@@ -29,11 +34,8 @@ jobs:
           sourcefile-path: authzed.gemspec
           version-regex: 's.version     = "(.+)"'
           version-change: minor
-      - name: "Install ruby"
-        uses: "ruby/setup-ruby@v1"
-        with:
-          ruby-version: "3.3.0"
-          bundler-cache: true
+      - name: "Update Gemfile"
+        run: "bundle install" 
       - name: "Install protoc"
         uses: "arduino/setup-protoc@v3"
         with:
@@ -46,8 +48,6 @@ jobs:
           brew install grpc
           which grpc_ruby_plugin
           echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
-      - name: "Install dependencies"
-        run: "bundle install"
       - name: "Install buf"
         uses: "bufbuild/buf-setup-action@v1.32.0"
         with:

--- a/.github/workflows/manual-api-update.yaml
+++ b/.github/workflows/manual-api-update.yaml
@@ -26,6 +26,11 @@ jobs:
           UPDATED_STATUS: ${{ steps.buf-update.outputs.updated }}
         run: |
           echo "Update status: $UPDATED_STATUS"
+      - name: "Install ruby and dependencies"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "3.3.0"
+          bundler-cache: true
       - name: "Update package version"
         uses: authzed/actions/semver-update@main
         if: steps.buf-update.outputs.updated == 'true'
@@ -33,11 +38,8 @@ jobs:
           sourcefile-path: authzed.gemspec
           version-regex: 's.version     = "(.+)"'
           version-change: minor
-      - name: "Install ruby"
-        uses: "ruby/setup-ruby@v1"
-        with:
-          ruby-version: "3.3.0"
-          bundler-cache: true
+      - name: "Update Gemfile"
+        run: "bundle install"
       - name: "Install protoc"
         uses: "arduino/setup-protoc@v3"
         with:
@@ -50,8 +52,6 @@ jobs:
           brew install grpc
           which grpc_ruby_plugin
           echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
-      - name: "Install dependencies"
-        run: "bundle install"
       - name: "Install buf"
         uses: "bufbuild/buf-setup-action@v1.32.0"
         with:


### PR DESCRIPTION
Gemfile.lock mismatch was happening because the file isn't updated after the version bump in the workflow.