### PR TITLE
Add example for user-defined roles based on Authzed's guide

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -18,19 +18,19 @@ definition document {
 	permission view = reader + edit
 }
 
-/** user represents a user that can be granted role(s) */
-definition user {}
+/** project represents a project that can have issues created in it. */
+definition project {
+	/** writer indicates that the user is a writer on the document. */
+	relation issue_creator: role#member
+}
 
 /** role represents a role that can be granted to a user. */
 definition role {
-  relation member: user
+	relation member: user
 }
 
-/** project represents a project that can have issues created in it. */
-definition project {
-  relation issue_creator: role#member
-}
-"''
+/** user represents a user that can be granted role(s) */
+definition user {}"''
 
 describe 'Client', '#schema' do
   let(:client) do
@@ -250,10 +250,18 @@ describe 'Client', '#permissions' do
           ]
         )
 
-        response = client.acl_service.write_relationships(request)
+        response = client.permissions_service.write_relationships(request)
 
         expect(response).to be_a(Authzed::Api::V1::WriteRelationshipsResponse)
         expect(response.written_at.token).not_to be_nil
+
+        resp = client.permissions_service.read_relationships(
+          Authzed::Api::V1::ReadRelationshipsRequest.new(
+            consistency: Authzed::Api::V1::Consistency.new(fully_consistent: true),
+            relationship_filter: Authzed::Api::V1::RelationshipFilter.new(resource_type: 'project')
+          )
+        )
+        expect(resp.count).to eq 1
       end
     end
   end


### PR DESCRIPTION
This PR adds an example to the `client_spec.rb` file, demonstrating how to use the Authzed Ruby client to write a relationship for user-defined roles, as described in the [Authzed blog post on user-defined roles](https://authzed.com/blog/user-defined-roles).

Background:
While following the guide, I encountered the following pseudocode:

```
# Grant the "issue_creator" capability to those who have been granted the "project_manager" role
authzed.write(resource="project:oursoftware", relation="issue_creator", subject="role:project_manager#member")
```

It wasn't immediately clear how to translate this into Ruby code using Authzed's Ruby gem, particularly with respect to constructing the request for creating the relationship.

As mentioned in the issue, this is technically documented on https://buf.build/authzed/api/docs/main:authzed.api.v1#authzed.api.v1.SubjectReference, but I believe an rspec example can help and it doesn't hurt.

Closes https://github.com/authzed/authzed-rb/issues/142. 