### PR TITLE
chore: add conventional commit linting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     groups:
       bundler:
         patterns: ["*"]
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -17,3 +21,7 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"

--- a/.github/workflows/automatic-api-update.yaml
+++ b/.github/workflows/automatic-api-update.yaml
@@ -36,6 +36,10 @@ jobs:
         with:
           delete-branch: "true"
           title: "Update API to ${{ github.event.client_payload.BUFTAG }}"
+          commit-message: "chore: update api version"
           branch: "api-change/${{ github.event.client_payload.BUFTAG }}"
+          # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+          # This is how we ensure that workflows run
+          draft: "always-true"
           base: "main"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,25 +25,12 @@ jobs:
       - name: "Run rspec"
         run: "bundle exec rspec"
 
-  protobuf:
-    name: "Generate Protobufs"
-    runs-on: "ubuntu-latest"
+  conventional-commits:
+    name: "Lint Commit Messages"
+    permissions:
+      contents: "read"
+    runs-on: "depot-ubuntu-24.04-small"
+    if: "github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened' || github.event.action == 'edited')"
     steps:
       - uses: "actions/checkout@v6"
-      - uses: "ruby/setup-ruby@v1"
-        with:
-          bundler-cache: true
-      - uses: "arduino/setup-protoc@v3"
-        with:
-          version: "24.4"
-      - name: "Install Homebrew & gRPC"
-        run: |
-          bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/runner/.bash_profile
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          brew install grpc
-          which grpc_ruby_plugin
-          echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
-      - uses: "bufbuild/buf-setup-action@v1.50.0"
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: "webiny/action-conventional-commits@v1.3.0"

--- a/.github/workflows/manual-api-update.yaml
+++ b/.github/workflows/manual-api-update.yaml
@@ -41,6 +41,10 @@ jobs:
         with:
           delete-branch: "true"
           title: Update API to ${{ inputs.buftag }}
+          # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+          # This is how we ensure that workflows run
+          draft: "always-true"
+          commit-message: "chore: update api version"
           branch: api-change/${{ inputs.buftag }}
           base: "main"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
Part of preparing this repo for the use of `release-please`. We need to have conventional commits in place, so this adds a linter for that and does some other drive-by refactors to workflows.

## Changes
* Add conventional commit linting
* Make the `create-pull-request` action tag with a conventional commit (`feat` to trigger a release)
* Ensure that dependabot uses conventional commits
* Some drive-by refactors

## Testing
Review. See that tests pass.